### PR TITLE
Fix README domain reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# elendmire.github.io
+# farukavci.me
+
+This repository hosts the source for the personal website at [https://farukavci.me](https://farukavci.me).


### PR DESCRIPTION
## Summary
- update README with correct site domain and more details

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857f02f70008323a6c7175a22cc35e2